### PR TITLE
Getting latest from upstream

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -50,8 +50,10 @@ This means that even if someone has access to the Redis store, the passwords are
 Requirements
 ------------
 
-* Redis
-* Python 2.7+ or 3.4+ (both included)
+* `Redis`_
+* Python 2.7+ or 3.5+
+
+.. _Redis: https://redis.io/
 
 Installation
 ------------
@@ -66,7 +68,9 @@ Installation
 Configuration
 -------------
 
-You can configure the following via environment variables.
+Start by ensuring that Redis is up and running.
+
+Then, you can configure the following via environment variables.
 
 ``SECRET_KEY``: unique key that's used to sign key. This should
 be kept secret.  See the `Flask Documentation`__ for more information.
@@ -93,6 +97,8 @@ need to change this.
 ``REDIS_URL``: (optional) will be used instead of ``REDIS_HOST``, ``REDIS_PORT``, and ``SNAPPASS_REDIS_DB`` to configure the Redis client object. For example: redis://username:password@localhost:6379/0
 
 ``REDIS_PREFIX``: (optional, defaults to ``"snappass"``) prefix used on redis keys to prevent collisions with other potential clients
+
+``HOST_OVERRIDE``: (optional) Used to override the base URL if the app is unaware. Useful when running behind reverse proxies like an identity-aware SSO. Example: ``sub.domain.com``
 
 Docker
 ------

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,11 @@
 asn1crypto==1.3.0
 cffi==1.14.0
 click==7.1.2
-cryptography==3.2
+cryptography==3.3.2
 Flask==1.0.2
 idna==2.9
 itsdangerous==0.24
-Jinja2==2.10.1
+Jinja2==2.11.3
 MarkupSafe==1.1.1
 pycparser==2.20
 redis==2.10.6

--- a/snappass/main.py
+++ b/snappass/main.py
@@ -13,6 +13,7 @@ from distutils.util import strtobool
 
 NO_SSL = bool(strtobool(os.environ.get('NO_SSL', 'False')))
 URL_PREFIX = os.environ.get('URL_PREFIX', None)
+HOST_OVERRIDE = os.environ.get('HOST_OVERRIDE', None)
 TOKEN_SEPARATOR = '~'
 
 
@@ -164,9 +165,15 @@ def handle_password():
     token = set_password(password, ttl)
 
     if NO_SSL:
-        base_url = request.url_root
+        if HOST_OVERRIDE:
+            base_url = f'http://{HOST_OVERRIDE}/'
+        else:
+            base_url = request.url_root
     else:
-        base_url = request.url_root.replace("http://", "https://")
+        if HOST_OVERRIDE:
+            base_url = f'https://{HOST_OVERRIDE}/'
+        else:
+            base_url = request.url_root.replace("http://", "https://")
     if URL_PREFIX:
         base_url = base_url + URL_PREFIX.strip("/") + "/"
     link = base_url + url_quote_plus(token)


### PR DESCRIPTION
- Link to redis.io and bump Python requirement to 3.5+
- Note that Redis must be running
- Bump cryptography from 3.2 to 3.3.2
- Bump jinja2 from 2.10.1 to 2.11.3
- Allowing full host override (#143)
