### PR TITLE
Bringing in latest from upstream

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,6 +1,0 @@
-[bumpversion]
-files = setup.py
-commit = True
-tag = True
-current_version = 1.5.0
-

--- a/.dockerignore
+++ b/.dockerignore
@@ -6,7 +6,6 @@
 CONTRIBUTING.rst
 docker-compose.yml
 Dockerfile
-requirements.txt
 tests.py
 tox.ini
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
         python-version: ['3.8', '3.9', '3.10']
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,12 +8,13 @@ RUN groupadd -r snappass && \
 
 WORKDIR $APP_DIR
 
-COPY ["setup.py", "MANIFEST.in", "README.rst", "AUTHORS.rst", "$APP_DIR/"]
+COPY ["setup.py", "requirements.txt", "MANIFEST.in", "README.rst", "AUTHORS.rst", "$APP_DIR/"]
 COPY ["./snappass", "$APP_DIR/snappass"]
 
 RUN python setup.py install && \
     chown -R snappass $APP_DIR && \
     chgrp -R snappass $APP_DIR
+RUN pip install -r requirements.txt
 
 USER snappass
 

--- a/README.rst
+++ b/README.rst
@@ -47,7 +47,7 @@ Requirements
 ------------
 
 * `Redis`_
-* Python 3.7+
+* Python 3.8+
 
 .. _Redis: https://redis.io/
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,7 +1,9 @@
 coverage==7.2.7
-fakeredis==2.14.1
+fakeredis==2.20.0
 flake8==6.0.0
 freezegun==1.2.1
 pytest==7.3.1
 pytest-cov==4.1.0
-tox==4.6.0
+tox==4.11.3
+bumpversion==0.6.0
+wheel==0.42.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-cryptography==41.0.1
+cryptography==41.0.4
 Flask==2.3.2
 itsdangerous==2.1.2
 Jinja2==3.1.2
 MarkupSafe==2.1.1
-redis==4.5.5
+redis==5.0.1
 Werkzeug==2.3.3

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,10 +1,9 @@
 [bumpversion]
-current_version = 1.6.0
+current_version = 1.6.1
 commit = True
 tag = True
-files = setup.py snappass/__init__.py
+files = setup.py
 
 [flake8]
 show-source = True
 max-line-length = 120
-

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='snappass',
-    version='1.6.0',
+    version='1.6.1',
     description="It's like SnapChat... for Passwords.",
     long_description=(open('README.rst').read() + '\n\n' +
                       open('AUTHORS.rst').read()),
@@ -18,7 +18,7 @@ setup(
         ],
     },
     include_package_data=True,
-    python_requires='>=3.7, <4',
+    python_requires='>=3.8, <4',
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',
@@ -27,7 +27,6 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',

--- a/snappass/main.py
+++ b/snappass/main.py
@@ -7,8 +7,8 @@ import redis
 from cryptography.fernet import Fernet
 from flask import abort, Flask, render_template, request, jsonify
 from redis.exceptions import ConnectionError
-from werkzeug.urls import url_quote_plus
-from werkzeug.urls import url_unquote_plus
+from urllib.parse import quote_plus
+from urllib.parse import unquote_plus
 from distutils.util import strtobool
 
 NO_SSL = bool(strtobool(os.environ.get('NO_SSL', 'False')))
@@ -176,7 +176,7 @@ def handle_password():
             base_url = request.url_root.replace("http://", "https://")
     if URL_PREFIX:
         base_url = base_url + URL_PREFIX.strip("/") + "/"
-    link = base_url + url_quote_plus(token)
+    link = base_url + quote_plus(token)
     if request.accept_mimetypes.accept_json and not request.accept_mimetypes.accept_html:
         return jsonify(link=link, ttl=ttl)
     else:
@@ -185,7 +185,7 @@ def handle_password():
 
 @app.route('/<password_key>', methods=['GET'])
 def preview_password(password_key):
-    password_key = url_unquote_plus(password_key)
+    password_key = unquote_plus(password_key)
     if not password_exists(password_key):
         return render_template('expired.html'), 404
 
@@ -194,7 +194,7 @@ def preview_password(password_key):
 
 @app.route('/<password_key>', methods=['POST'])
 def show_password(password_key):
-    password_key = url_unquote_plus(password_key)
+    password_key = unquote_plus(password_key)
     password = get_password(password_key)
     if not password:
         return render_template('expired.html'), 404


### PR DESCRIPTION
- Remove py3.7 (#234)
- Bump cryptography from 39.0.2 to 41.0.1 (#260)
- Bump tox from 3.25.0 to 4.6.0 (#262)
- Bump fakeredis from 1.7.5 to 2.14.1 (#263)
- Bump flask from 2.1.2 to 2.3.2 (#250)
- Bump pytest from 7.1.2 to 7.3.1 (#243)
- Bump redis from 4.5.3 to 4.5.5 (#253)
- Bump coverage from 6.4.1 to 7.2.7 (#267)
- Bump pytest-cov from 3.0.0 to 4.1.0 (#266)
- Bump actions/checkout from 3 to 4 (#282)
- [Snyk] Security upgrade cryptography from 41.0.1 to 41.0.4 (#284)
- Bump tox from 4.6.0 to 4.11.3 (#287)
- Bump fakeredis from 2.14.1 to 2.20.0
- Bump redis from 4.5.5 to 5.0.1
- Install deps from requirements.txt (#303)
- Prepare 1.6.1 release (#304)
- Bump version: 1.6.0 → 1.6.1 (#305)
- Use urllib.parse for quoting/unquoting plus instead of deprecated werkzeug.urls (#300)
