### PR TITLE
ls/latest updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - uses: actions/cache@v3

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -36,10 +36,10 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
         config-file: ./.github/codeql-config.yml
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 cryptography==41.0.4
-Flask==2.3.2
+Flask==3.0.0
 itsdangerous==2.1.2
 Jinja2==3.1.2
 MarkupSafe==2.1.1
 redis==5.0.1
-Werkzeug==2.3.3
+Werkzeug==3.0.1


### PR DESCRIPTION
This is me pulling in the latest upstream improvements. No local changes.

- Remove py3.7 (#234)
- Bump cryptography from 39.0.2 to 41.0.1 (#260)
- Bump tox from 3.25.0 to 4.6.0 (#262)
- Bump fakeredis from 1.7.5 to 2.14.1 (#263)
- Bump flask from 2.1.2 to 2.3.2 (#250)
- Bump pytest from 7.1.2 to 7.3.1 (#243)
- Bump redis from 4.5.3 to 4.5.5 (#253)
- Bump coverage from 6.4.1 to 7.2.7 (#267)
- Bump pytest-cov from 3.0.0 to 4.1.0 (#266)
- Bump actions/checkout from 3 to 4 (#282)
- [Snyk] Security upgrade cryptography from 41.0.1 to 41.0.4 (#284)
- Bump tox from 4.6.0 to 4.11.3 (#287)
- Bump fakeredis from 2.14.1 to 2.20.0
- Bump redis from 4.5.5 to 5.0.1
- Install deps from requirements.txt (#303)
- Prepare 1.6.1 release (#304)
- Bump version: 1.6.0 → 1.6.1 (#305)
- Use urllib.parse for quoting/unquoting plus instead of deprecated werkzeug.urls (#300)
- Bump actions/setup-python from 4 to 5 (#306)
- Bump github/codeql-action from 2 to 3 (#309)
- Bump werkzeug from 2.3.3 to 3.0.1 (#295)
- Bump flask from 2.3.2 to 3.0.0 (#294)
