### PR TITLE
Pulling in latest commits from upstream master

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,6 @@
 coverage==7.2.7
 fakeredis==2.20.0
-flake8==6.0.0
+flake8==7.0.0
 freezegun==1.4.0
 pytest==7.4.4
 pytest-cov==4.1.0

--- a/snappass/main.py
+++ b/snappass/main.py
@@ -202,6 +202,12 @@ def show_password(password_key):
     return render_template('password.html', password=password)
 
 
+@app.route('/_/_/health', methods=['GET'])
+@check_redis_alive
+def health_check():
+    return {}
+
+
 @check_redis_alive
 def main():
     app.run(host='0.0.0.0')

--- a/tests.py
+++ b/tests.py
@@ -106,6 +106,11 @@ class SnapPassRoutesTestCase(TestCase):
         snappass.app.config['TESTING'] = True
         self.app = snappass.app.test_client()
 
+    def test_health_check(self):
+        response = self.app.get('/_/_/health')
+        self.assertEqual('200 OK', response.status)
+        self.assertEqual('{}', response.get_data(as_text=True).strip())
+
     def test_preview_password(self):
         password = "I like novelty kitten statues!"
         key = snappass.set_password(password, 30)


### PR DESCRIPTION
- Remove py3.7 (#234)
- Bump cryptography from 39.0.2 to 41.0.1 (#260)
- Bump tox from 3.25.0 to 4.6.0 (#262)
- Bump fakeredis from 1.7.5 to 2.14.1 (#263)
- Bump flask from 2.1.2 to 2.3.2 (#250)
- Bump pytest from 7.1.2 to 7.3.1 (#243)
- Bump redis from 4.5.3 to 4.5.5 (#253)
- Bump coverage from 6.4.1 to 7.2.7 (#267)
- Bump pytest-cov from 3.0.0 to 4.1.0 (#266)
- Bump actions/checkout from 3 to 4 (#282)
- [Snyk] Security upgrade cryptography from 41.0.1 to 41.0.4 (#284)
- Bump tox from 4.6.0 to 4.11.3 (#287)
- Bump fakeredis from 2.14.1 to 2.20.0
- Bump redis from 4.5.5 to 5.0.1
- Install deps from requirements.txt (#303)
- Prepare 1.6.1 release (#304)
- Bump version: 1.6.0 → 1.6.1 (#305)
- Use urllib.parse for quoting/unquoting plus instead of deprecated werkzeug.urls (#300)
- Bump actions/setup-python from 4 to 5 (#306)
- Bump github/codeql-action from 2 to 3 (#309)
- Bump werkzeug from 2.3.3 to 3.0.1 (#295)
- Bump flask from 2.3.2 to 3.0.0 (#294)
- Bump pytest from 7.3.1 to 7.4.4
- Bump version: 1.6.1 → 1.6.2 (#311)
- Bump freezegun from 1.2.1 to 1.4.0
- Bump flake8 from 6.0.0 to 7.0.0
- Add health check endpoint (#329)
