### PR TITLE
Bringing in latest from upstream repo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-python-${{ matrix.python-version }}-pip-${{ hashFiles('.github/workflows/ci.yml') }}

--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,7 @@ htmlcov/
 # virtualenv
 venv/
 ENV/
+
+# Translation catalogs
+*.mo
+*.pot

--- a/README.rst
+++ b/README.rst
@@ -96,6 +96,40 @@ need to change this.
 
 ``HOST_OVERRIDE``: (optional) Used to override the base URL if the app is unaware. Useful when running behind reverse proxies like an identity-aware SSO. Example: ``sub.domain.com``
 
+API
+---
+
+SnapPass also has a simple API that can be used to create passwords links. The advantage of using the API is that
+you can create a password and retrieve the link without having to open the web interface. This is useful if you want to
+embed it in a script or use it in a CI/CD pipeline.
+
+To create a password, send a POST request to ``/api/set_password`` like so:
+
+::
+
+    $ curl -X POST -H "Content-Type: application/json"  -d '{"password": "foobar"}' http://localhost:5000/api/set_password/
+
+This will return a JSON response with the password link:
+
+::
+
+    {
+        "link": "http://127.0.0.1:5000/snappassbedf19b161794fd288faec3eba15fa41~hHnILpQ50ZfJc3nurDfHCb_22rBr5gGEya68e_cZOrY%3D",
+        "ttl":1209600
+    }
+
+the default TTL is 2 weeks (1209600 seconds), but you can override it by adding a expiration parameter:
+
+::
+
+    $ curl -X POST -H "Content-Type: application/json"  -d '{"password": "foobar", "ttl": 3600 }' http://localhost:5000/api/set_password/
+
+Notes:
+
+- When using the API, you can specify any ttl, as long as it is lower than the default.
+- The password is passed in the body of the request rather than in the URL. This is to prevent the password from being logged in the server logs.
+- Depending on the environment you are running it, you might want to expose the ``/api`` endpoint to your internal network only, and put the web interface behind authentication.
+
 Docker
 ------
 

--- a/babel.cfg
+++ b/babel.cfg
@@ -1,0 +1,10 @@
+# Update Translations:
+# (venv) $ pybabel extract -F babel.cfg -o messages.pot .
+# (venv) $ pybabel update -i messages.pot -d snappass/translations
+# (venv) $ pybabel compile -d snappass/translations
+# Add a new language:
+# (venv) $ pybabel extract -F babel.cfg -o messages.pot .
+# (venv) $ pybabel init -i messages.pot -d snappass/translations -l <language_code>
+[python: snappass/**.py]
+[jinja2: snappass/templates/**.html]
+

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,9 +1,9 @@
-coverage==7.2.7
-fakeredis==2.20.0
+coverage==7.4.2
+fakeredis==2.21.1
 flake8==7.0.0
 freezegun==1.4.0
-pytest==7.4.4
+pytest==8.1.0
 pytest-cov==4.1.0
-tox==4.11.3
+tox==4.13.0
 bumpversion==0.6.0
 wheel==0.42.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
-cryptography==42.0.0
+cryptography==42.0.3
 Flask==3.0.0
 itsdangerous==2.1.2
 Jinja2==3.1.3
 MarkupSafe==2.1.1
 redis==5.0.1
 Werkzeug==3.0.1
+flask-babel

--- a/snappass/main.py
+++ b/snappass/main.py
@@ -10,12 +10,12 @@ from redis.exceptions import ConnectionError
 from urllib.parse import quote_plus
 from urllib.parse import unquote_plus
 from distutils.util import strtobool
+from flask_babel import Babel
 
 NO_SSL = bool(strtobool(os.environ.get('NO_SSL', 'False')))
 URL_PREFIX = os.environ.get('URL_PREFIX', None)
 HOST_OVERRIDE = os.environ.get('HOST_OVERRIDE', None)
 TOKEN_SEPARATOR = '~'
-
 
 # Initialize Flask Application
 app = Flask(__name__)
@@ -25,9 +25,18 @@ app.secret_key = os.environ.get('SECRET_KEY', 'Secret Key')
 app.config.update(
     dict(STATIC_URL=os.environ.get('STATIC_URL', 'static')))
 
+
+# Set up Babel
+def get_locale():
+    return request.accept_languages.best_match(['en', 'es', 'de', 'nl'])
+
+
+babel = Babel(app, locale_selector=get_locale)
+
 # Initialize Redis
 if os.environ.get('MOCK_REDIS'):
     from fakeredis import FakeStrictRedis
+
     redis_client = FakeStrictRedis()
 elif os.environ.get('REDIS_URL'):
     redis_client = redis.StrictRedis.from_url(os.environ.get('REDIS_URL'))
@@ -39,7 +48,10 @@ else:
         host=redis_host, port=redis_port, db=redis_db)
 REDIS_PREFIX = os.environ.get('REDIS_PREFIX', 'snappass')
 
-TIME_CONVERSION = {'two weeks': 1209600, 'week': 604800, 'day': 86400, 'hour': 3600}
+TIME_CONVERSION = {'two weeks': 1209600, 'week': 604800, 'day': 86400,
+                   'hour': 3600}
+DEFAULT_API_TTL = 1209600
+MAX_TTL = DEFAULT_API_TTL
 
 
 def check_redis_alive(fn):
@@ -54,6 +66,7 @@ def check_redis_alive(fn):
                 sys.exit(0)
             else:
                 return abort(500)
+
     return inner
 
 
@@ -154,6 +167,22 @@ def clean_input():
     return TIME_CONVERSION[time_period], request.form['password']
 
 
+def set_base_url(req):
+    if NO_SSL:
+        if HOST_OVERRIDE:
+            base_url = f'http://{HOST_OVERRIDE}/'
+        else:
+            base_url = req.url_root
+    else:
+        if HOST_OVERRIDE:
+            base_url = f'https://{HOST_OVERRIDE}/'
+        else:
+            base_url = req.url_root.replace("http://", "https://")
+    if URL_PREFIX:
+        base_url = base_url + URL_PREFIX.strip("/") + "/"
+    return base_url
+
+
 @app.route('/', methods=['GET'])
 def index():
     return render_template('set_password.html')
@@ -161,26 +190,33 @@ def index():
 
 @app.route('/', methods=['POST'])
 def handle_password():
-    ttl, password = clean_input()
-    token = set_password(password, ttl)
-
-    if NO_SSL:
-        if HOST_OVERRIDE:
-            base_url = f'http://{HOST_OVERRIDE}/'
+    password = request.form.get('password')
+    ttl = request.form.get('ttl')
+    if clean_input():
+        ttl = TIME_CONVERSION[ttl.lower()]
+        token = set_password(password, ttl)
+        base_url = set_base_url(request)
+        link = base_url + quote_plus(token)
+        if request.accept_mimetypes.accept_json and not \
+           request.accept_mimetypes.accept_html:
+            return jsonify(link=link, ttl=ttl)
         else:
-            base_url = request.url_root
+            return render_template('confirm.html', password_link=link)
     else:
-        if HOST_OVERRIDE:
-            base_url = f'https://{HOST_OVERRIDE}/'
-        else:
-            base_url = request.url_root.replace("http://", "https://")
-    if URL_PREFIX:
-        base_url = base_url + URL_PREFIX.strip("/") + "/"
-    link = base_url + quote_plus(token)
-    if request.accept_mimetypes.accept_json and not request.accept_mimetypes.accept_html:
+        abort(500)
+
+
+@app.route('/api/set_password/', methods=['POST'])
+def api_handle_password():
+    password = request.json.get('password')
+    ttl = int(request.json.get('ttl', DEFAULT_API_TTL))
+    if password and isinstance(ttl, int) and ttl <= MAX_TTL:
+        token = set_password(password, ttl)
+        base_url = set_base_url(request)
+        link = base_url + quote_plus(token)
         return jsonify(link=link, ttl=ttl)
     else:
-        return render_template('confirm.html', password_link=link)
+        abort(500)
 
 
 @app.route('/<password_key>', methods=['GET'])

--- a/snappass/templates/base.html
+++ b/snappass/templates/base.html
@@ -1,8 +1,7 @@
 <!DOCTYPE html>
-<html lang="en">
-
-<head>
-    <title>TrackAbout Snappass - Secret Sharing Service</title>
+<html lang="{{ _('en') }}">
+  <head>
+    <title>{{ _('TrackAbout Snappass - Secret Sharing Service') }}</title>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
@@ -16,10 +15,9 @@
         <div class="container">
             <div class="navbar-header">
                 <div style="margin-top:15px">
-                    <a class="logo"><img src="static/ta-logo.png"></img>
-                    </a>
+                    <a class="logo"><img src="static/ta-logo.png" /></a>
                 </div>
-                <a class="navbar-brand" href="/">Secret Sharing Service</a>
+                <a class="navbar-brand" href="/">{{ _('Share Secret') }}</a>
             </div>
         </div>
     </nav>

--- a/snappass/templates/confirm.html
+++ b/snappass/templates/confirm.html
@@ -3,15 +3,15 @@
 {% block content %}
 <div class="container">
   <section>
-    <div class="page-header"><h1>Share Secret Link</h1></div>
-    <p>The secret has been temporarily saved. Send the following URL to your intended recipient.</p>
+    <div class="page-header"><h1>{{ _('Share Secret Link') }}</h1></div>
+    <p>{{ _('The secret has been temporarily saved. Send the following URL to your intended recipient.') }}</p>
     <div class="row">
       <div class="col-sm-6 margin-bottom-10">
         <input type="text" class="form-control" id="password-link" value="{{ password_link }}" readonly="readonly">
       </div>
 
       <div class="col-sm-6">
-        <button title="Copy to clipboard" type="button" class="btn btn-primary copy-clipboard-btn"
+        <button title="{{ _('Copy to clipboard') }}" type="button" class="btn btn-primary copy-clipboard-btn"
               id="copy-clipboard-btn" data-clipboard-target="#password-link"
               data-placement='bottom'>
           <i class="fa fa-clipboard"></i>

--- a/snappass/templates/expired.html
+++ b/snappass/templates/expired.html
@@ -3,9 +3,9 @@
 {% block content %}
 <div class="container">
   <section>
-    <div class="page-header"><h1>Secret not found</h1></div>
-    <p class="lead">The requested URL was not found on the server. This could be because this URL never contained a secret, or because it expired or was revealed earlier.</p>
-    <p class="lead">If this URL was sent to you by someone, make sure to check your spelling or ask the person who sent it to you to send a new secret.</p>
+    <div class="page-header"><h1>{{ _('Secret not found') }}</h1></div>
+    <p class="lead">{{ _('The requested URL was not found on the server. This could be because this URL never contained a secret, or because it expired or was revealed earlier.') }}</p>
+    <p class="lead">{{ _('If this URL was sent to you by someone, make sure to check your spelling or ask the person who sent it to you to send a new secret.') }}</p>
   </section>
 </div>
 {% endblock %}

--- a/snappass/templates/password.html
+++ b/snappass/templates/password.html
@@ -3,22 +3,22 @@
 {% block content %}
 <div class="container">
   <section>
-    <div class="page-header"><h1>Secret</h1></div>
-    <p>Save the following secret to a secure location.</p>
+    <div class="page-header"><h1>{{ _('Secret') }}</h1></div>
+    <p>{{ _('Save the following secret to a secure location.') }}</p>
     <div class="row">
       <div class="col-sm-6 margin-bottom-10">
         <textarea class="form-control" rows="10" cols="50" id="password-text" name="password-text" readonly="readonly">{{ password }}</textarea>
       </div>
 
       <div class="col-sm-6">
-        <button title="Copy to clipboard" type="button" class="btn btn-primary copy-clipboard-btn"
+        <button title="{{ _('Copy to clipboard') }}" type="button" class="btn btn-primary copy-clipboard-btn"
               id="copy-clipboard-btn" data-clipboard-target="#password-text"
               data-placement='bottom'>
           <i class="fa fa-clipboard"></i>
         </button>
       </div>
     </div>
-    <p>The secret has now been permanently deleted from the system, and the URL will no longer work. Refresh this page to verify.</p>
+    <p>{{ _('The secret has now been permanently deleted from the system, and the URL will no longer work. Refresh this page to verify.') }}</p>
   </section>
 </div>
 {% endblock %}

--- a/snappass/templates/preview.html
+++ b/snappass/templates/preview.html
@@ -4,12 +4,12 @@
 <div class="container">
   <section>
     <div class="page-header">
-      <h1>Secret</h1>
+      <h1>{{ _('Secret') }}</h1>
     </div>
-    <p class="lead">You can only reveal the secret once!</p>
+    <p class="lead">{{ _('You can only reveal the secret once!') }}</p>
     <div class="row">
       <div class="col-sm-6 margin-bottom-10">
-        <button id="revealSecret" type="button" class="btn-lg btn-primary">Reveal secret</button>
+        <button id="revealSecret" type="button" class="btn-lg btn-primary">{{ _('Reveal secret') }}</button>
       </div>
     </div>
   </section>

--- a/snappass/templates/set_password.html
+++ b/snappass/templates/set_password.html
@@ -3,27 +3,27 @@
 {% block content %}
 <div class="container">
   <section>
-    <div class="page-header"><h1>Set Secret</h1></div>
+    <div class="page-header"><h1>{{ _('Set Secret') }}</h1></div>
     <div class="row">
       <form role="form" id="password_create" method="post" autocomplete="off">
         <div class="col-sm-6 margin-bottom-10">
           <div class="input-group">
             <span class="input-group-addon" id="basic-addon1"><span class="glyphicon glyphicon-lock" aria-hidden="true"></span></span>
-            <textarea rows="10" cols="50" id="password" name="password" autofocus="true" class="form-control" placeholder="This service allows you to share secrets in a secure, ephemeral way. Input a single or multi-line secret, its expiration time, and click Generate URL. Share the one-time use URL with your intended recipient." aria-describedby="basic-addon1" autocomplete="off" required></textarea>
+            <textarea rows="10" cols="50" id="password" name="password" autofocus="true" class="form-control" placeholder="{{ _('SnapPass allows you to share secrets in a secure, ephemeral way. Input a single or multi-line secret, its expiration time, and click Generate URL. Share the one-time use URL with your intended recipient.') }}" aria-describedby="basic-addon1" autocomplete="off" required></textarea>
           </div>
         </div>
 
         <div class="col-sm-2 margin-bottom-10">
           <select class="form-control" name="ttl">
-            <option value="Two Weeks">Two Weeks</option>
-            <option value="Week" selected="selected">Week</option>
-            <option value="Day">Day</option>
-            <option value="Hour">Hour</option>
+            <option value="Two Weeks">{{ _('Two Weeks') }}</option>
+            <option value="Week" selected="selected">{{ _('Week') }}</option>
+            <option value="Day">{{ _('Day') }}</option>
+            <option value="Hour">{{ _('Hour') }}</option>
           </select>
         </div>
 
         <div class="col-sm-4">
-          <button type="submit" class="btn btn-primary" id="submit">Generate URL</button>
+          <button type="submit" class="btn btn-primary" id="submit">{{ _('Generate URL') }}</button>
         </div>
       </form>
     </div>

--- a/snappass/translations/de/LC_MESSAGES/messages.po
+++ b/snappass/translations/de/LC_MESSAGES/messages.po
@@ -1,0 +1,131 @@
+# German translations for SNAPPASS.
+# Copyright (C) 2024 ORGANIZATION
+# This file is distributed under the same license as the PROJECT project.
+# systeembeheerder <systeembeheerder@users.noreply.github.com>, 2024.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: PROJECT VERSION\n"
+"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
+"POT-Creation-Date: 2024-02-22 11:01+0100\n"
+"PO-Revision-Date: 2024-02-16 09:29+0100\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: de\n"
+"Language-Team: de <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.14.0\n"
+
+#: snappass/templates/base.html:2
+msgid "en"
+msgstr "de"
+
+#: snappass/templates/base.html:4
+msgid "Snappass - Share Secrets"
+msgstr "Snappass - Passwort teilen"
+
+#: snappass/templates/base.html:16
+msgid "Share Secret"
+msgstr "Passwort teilen"
+
+#: snappass/templates/confirm.html:6
+msgid "Share Secret Link"
+msgstr "Geheimen Link teilen"
+
+#: snappass/templates/confirm.html:7
+msgid ""
+"The secret has been temporarily saved. Send the following URL to your "
+"intended recipient."
+msgstr ""
+"Das Geheimnis wurde vorübergehend gespeichert. Senden Sie die folgende "
+"URL an Ihre gewünschten Empfänger."
+
+#: snappass/templates/confirm.html:14 snappass/templates/password.html:14
+msgid "Copy to clipboard"
+msgstr "In Zwischenablage kopieren"
+
+#: snappass/templates/expired.html:6
+msgid "Secret not found"
+msgstr "Passwort nicht gefunden"
+
+#: snappass/templates/expired.html:7
+msgid ""
+"The requested URL was not found on the server. This could be because this"
+" URL never contained a secret, or because it expired or was revealed "
+"earlier."
+msgstr ""
+"Die angeforderte URL wurde auf dem Server nicht gefunden. Dies könnte "
+"daran liegen, dass diesDie URL enthielt nie ein Passwort, oder weil sie "
+"abgelaufen ist oder offengelegt wurde "
+
+#: snappass/templates/expired.html:8
+msgid ""
+"If this URL was sent to you by someone, make sure to check your spelling "
+"or ask the person who sent it to you to send a new secret."
+msgstr ""
+"Wenn Ihnen diese URL von jemandem gesendet wurde, überprüfen Sie "
+"unbedingt Ihre Rechtschreibung oder bitten Sie die Person, die es Ihnen "
+"geschickt hat, ein neues Passwort zu senden."
+
+#: snappass/templates/password.html:6 snappass/templates/preview.html:7
+msgid "Secret"
+msgstr "Geheim"
+
+#: snappass/templates/password.html:7
+msgid "Save the following secret to a secure location."
+msgstr "Speichern Sie dass folgende Passwort an einem sicheren Ort."
+
+#: snappass/templates/password.html:21
+msgid ""
+"The secret has now been permanently deleted from the system, and the URL "
+"will no longer work. Refresh this page to verify."
+msgstr ""
+" Dass Passwort wurde nun endgültig aus dem System gelöscht, und die URL "
+"funktioniert nicht mehr. Aktualisieren Sie diese Seite, um dies zu "
+"überprüfen."
+
+#: snappass/templates/preview.html:9
+msgid "You can only reveal the secret once!"
+msgstr "Du kannst das Passwort nur einmal lüften!"
+
+#: snappass/templates/preview.html:12
+msgid "Reveal secret"
+msgstr "Passwort lüften"
+
+#: snappass/templates/set_password.html:6
+msgid "Set Secret"
+msgstr "Geheimen Schlüssel festlegen"
+
+#: snappass/templates/set_password.html:12
+msgid ""
+"SnapPass allows you to share secrets in a secure, ephemeral way. Input a "
+"single or multi-line secret, its expiration time, and click Generate URL."
+" Share the one-time use URL with your intended recipient."
+msgstr ""
+"SnapPass ermöglicht es Ihnen, Passwörter auf sichere, kurzlebige Weise zu"
+" teilen. Input a ein- oder mehrzeiliges Passwort, die Ablaufzeit und "
+"klicken Sie auf URL generieren.Teilen Sie die URL für den einmaligen "
+"Gebrauch mit dem beabsichtigten Empfänger."
+
+#: snappass/templates/set_password.html:18
+msgid "Two Weeks"
+msgstr "Zwei Wochen"
+
+#: snappass/templates/set_password.html:19
+msgid "Week"
+msgstr "Woche"
+
+#: snappass/templates/set_password.html:20
+msgid "Day"
+msgstr "Tag"
+
+#: snappass/templates/set_password.html:21
+msgid "Hour"
+msgstr "Stunde"
+
+#: snappass/templates/set_password.html:26
+msgid "Generate URL"
+msgstr "URL generieren"
+

--- a/snappass/translations/es/LC_MESSAGES/messages.po
+++ b/snappass/translations/es/LC_MESSAGES/messages.po
@@ -1,0 +1,129 @@
+# Spanish translations for SNAPPASS.
+# Copyright (C) 2024 ORGANIZATION
+# This file is distributed under the same license as the PROJECT project.
+# systeembeheerder <systeembeheerder@users.noreply.github.com>, 2024.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: PROJECT VERSION\n"
+"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
+"POT-Creation-Date: 2024-02-22 11:01+0100\n"
+"PO-Revision-Date: 2024-02-16 09:29+0100\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: es\n"
+"Language-Team: es <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.14.0\n"
+
+#: snappass/templates/base.html:2
+msgid "en"
+msgstr "es"
+
+#: snappass/templates/base.html:4
+msgid "Snappass - Share Secrets"
+msgstr "Snappass - Compartir secretos"
+
+#: snappass/templates/base.html:16
+msgid "Share Secret"
+msgstr "Compartir secretos"
+
+#: snappass/templates/confirm.html:6
+msgid "Share Secret Link"
+msgstr "Compartir enlace secreto"
+
+#: snappass/templates/confirm.html:7
+msgid ""
+"The secret has been temporarily saved. Send the following URL to your "
+"intended recipient."
+msgstr ""
+"El secreto se ha guardado temporalmente. Envíe la siguiente URL a "
+"sudestinatario previsto."
+
+#: snappass/templates/confirm.html:14 snappass/templates/password.html:14
+msgid "Copy to clipboard"
+msgstr "Copiar en el portapapeles"
+
+#: snappass/templates/expired.html:6
+msgid "Secret not found"
+msgstr "Secreto no encontrado"
+
+#: snappass/templates/expired.html:7
+msgid ""
+"The requested URL was not found on the server. This could be because this"
+" URL never contained a secret, or because it expired or was revealed "
+"earlier."
+msgstr ""
+"La URL solicitada no se encontró en el servidor. Esto podría deberse a "
+"estoLa URL nunca contenía un secreto, o porque caducó o fue revelado "
+"Antes."
+
+#: snappass/templates/expired.html:8
+msgid ""
+"If this URL was sent to you by someone, make sure to check your spelling "
+"or ask the person who sent it to you to send a new secret."
+msgstr ""
+"Si alguien te envió esta URL, asegúrate de revisar tu ortografíaO pídele "
+"a la persona que te lo envió que te envíe un nuevo secreto."
+
+#: snappass/templates/password.html:6 snappass/templates/preview.html:7
+msgid "Secret"
+msgstr "Secreto"
+
+#: snappass/templates/password.html:7
+msgid "Save the following secret to a secure location."
+msgstr "Guarda el siguiente secreto en un lugar seguro."
+
+#: snappass/templates/password.html:21
+msgid ""
+"The secret has now been permanently deleted from the system, and the URL "
+"will no longer work. Refresh this page to verify."
+msgstr ""
+"El secreto ahora se ha eliminado permanentemente del sistema, y la URL Ya"
+" no funcionará. Actualiza esta página para verificarlo."
+
+#: snappass/templates/preview.html:9
+msgid "You can only reveal the secret once!"
+msgstr "¡Solo puedes revelar el secreto una vez!"
+
+#: snappass/templates/preview.html:12
+msgid "Reveal secret"
+msgstr "Revelar secreto"
+
+#: snappass/templates/set_password.html:6
+msgid "Set Secret"
+msgstr "Establecer secreto"
+
+#: snappass/templates/set_password.html:12
+msgid ""
+"SnapPass allows you to share secrets in a secure, ephemeral way. Input a "
+"single or multi-line secret, its expiration time, and click Generate URL."
+" Share the one-time use URL with your intended recipient."
+msgstr ""
+"SnapPass te permite compartir secretos de forma segura y efímera. "
+"Introduzca un secreto de una o varias líneas, su tiempo de caducidad y "
+"haga clic en Generar URL.Comparta la URL de un solo uso con el "
+"destinatario previsto\""
+
+#: snappass/templates/set_password.html:18
+msgid "Two Weeks"
+msgstr "Dos semanas"
+
+#: snappass/templates/set_password.html:19
+msgid "Week"
+msgstr "Semana"
+
+#: snappass/templates/set_password.html:20
+msgid "Day"
+msgstr "Día"
+
+#: snappass/templates/set_password.html:21
+msgid "Hour"
+msgstr "Hora"
+
+#: snappass/templates/set_password.html:26
+msgid "Generate URL"
+msgstr "Generar URL"
+

--- a/snappass/translations/nl/LC_MESSAGES/messages.po
+++ b/snappass/translations/nl/LC_MESSAGES/messages.po
@@ -1,0 +1,128 @@
+# Dutch translations for SNAPPASS.
+# Copyright (C) 2024 ORGANIZATION
+# This file is distributed under the same license as the PROJECT project.
+# systeembeheerder <systeembeheerder@users.noreply.github.com>, 2024.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: PROJECT VERSION\n"
+"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
+"POT-Creation-Date: 2024-02-22 11:01+0100\n"
+"PO-Revision-Date: 2024-02-14 21:16+0100\n"
+"Last-Translator: \n"
+"Language: nl\n"
+"Language-Team: nl <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.14.0\n"
+
+#: snappass/templates/base.html:2
+msgid "en"
+msgstr "nl"
+
+#: snappass/templates/base.html:4
+msgid "Snappass - Share Secrets"
+msgstr "Snappass - Deel Wachtwoorden"
+
+#: snappass/templates/base.html:16
+msgid "Share Secret"
+msgstr "Stel wachtwoord in"
+
+#: snappass/templates/confirm.html:6
+msgid "Share Secret Link"
+msgstr "Deel wachtwoord link"
+
+#: snappass/templates/confirm.html:7
+msgid ""
+"The secret has been temporarily saved. Send the following URL to your "
+"intended recipient."
+msgstr ""
+"Het wachtwoord is tijdelijk opgeslagen. Deel de volgende URL aan de "
+"bedoelde ontvanger."
+
+#: snappass/templates/confirm.html:14 snappass/templates/password.html:14
+msgid "Copy to clipboard"
+msgstr "Kopieer naar het klembord"
+
+#: snappass/templates/expired.html:6
+msgid "Secret not found"
+msgstr "Wachtwoord niet gevonden"
+
+#: snappass/templates/expired.html:7
+msgid ""
+"The requested URL was not found on the server. This could be because this"
+" URL never contained a secret, or because it expired or was revealed "
+"earlier."
+msgstr ""
+"De gevraagde URL is niet gevonden op de server. Dat kan omdat deze geen "
+"wachtwoord bevat, het is verlopen of het al eerder getoond is."
+
+#: snappass/templates/expired.html:8
+msgid ""
+"If this URL was sent to you by someone, make sure to check your spelling "
+"or ask the person who sent it to you to send a new secret."
+msgstr ""
+"Als deze URL naar u is toegestuurd, controleer de spelling of vraag de "
+"verzender om een nieuw wachtwoord link te versturen."
+
+#: snappass/templates/password.html:6 snappass/templates/preview.html:7
+msgid "Secret"
+msgstr "Wachtwoord"
+
+#: snappass/templates/password.html:7
+msgid "Save the following secret to a secure location."
+msgstr "Bewaar het wachtwoord op een veilige plek."
+
+#: snappass/templates/password.html:21
+msgid ""
+"The secret has now been permanently deleted from the system, and the URL "
+"will no longer work. Refresh this page to verify."
+msgstr ""
+"Het wachtwoord is permanent verwijderd van het systeem, de URL werkt niet"
+" meer. Herlaad deze pagina ter verificatie"
+
+#: snappass/templates/preview.html:9
+msgid "You can only reveal the secret once!"
+msgstr "Het wachtwoord wordt slechts eenmaal getoond!"
+
+#: snappass/templates/preview.html:12
+msgid "Reveal secret"
+msgstr "Onthul wachtwoord"
+
+#: snappass/templates/set_password.html:6
+msgid "Set Secret"
+msgstr "Stel wachtwoord in"
+
+#: snappass/templates/set_password.html:12
+msgid ""
+"SnapPass allows you to share secrets in a secure, ephemeral way. Input a "
+"single or multi-line secret, its expiration time, and click Generate URL."
+" Share the one-time use URL with your intended recipient."
+msgstr ""
+"We stellen je in staat om wachtwoorden op een veilige, tijdelijke manier "
+"te delen. Voer een enkel- of meerregelig wachwoord in, stel de vervaltijd"
+" in, en klik op 'URL genereren'. Deel de eenmalig te gebruiken URL met de"
+" beoogde ontvanger."
+
+#: snappass/templates/set_password.html:18
+msgid "Two Weeks"
+msgstr "Twee weken"
+
+#: snappass/templates/set_password.html:19
+msgid "Week"
+msgstr "Week"
+
+#: snappass/templates/set_password.html:20
+msgid "Day"
+msgstr "Dag"
+
+#: snappass/templates/set_password.html:21
+msgid "Hour"
+msgstr "Uur"
+
+#: snappass/templates/set_password.html:26
+msgid "Generate URL"
+msgstr "URL genereren"
+

--- a/tests.py
+++ b/tests.py
@@ -163,6 +163,44 @@ class SnapPassRoutesTestCase(TestCase):
             frozen_time.move_to("2020-05-22 12:00:00")
             self.assertIsNone(snappass.get_password(key))
 
+    def test_set_password_api(self):
+        with freeze_time("2020-05-08 12:00:00") as frozen_time:
+            password = 'my name is my passport. verify me.'
+            rv = self.app.post(
+                '/api/set_password/',
+                headers={'Accept': 'application/json'},
+                json={'password': password, 'ttl': '1209600'},
+            )
+
+            json_content = rv.get_json()
+            key = re.search(r'https://localhost/([^"]+)', json_content['link']).group(1)
+            key = unquote(key)
+
+            frozen_time.move_to("2020-05-22 11:59:59")
+            self.assertEqual(snappass.get_password(key), password)
+
+            frozen_time.move_to("2020-05-22 12:00:00")
+            self.assertIsNone(snappass.get_password(key))
+
+    def test_set_password_api_default_ttl(self):
+        with freeze_time("2020-05-08 12:00:00") as frozen_time:
+            password = 'my name is my passport. verify me.'
+            rv = self.app.post(
+                '/api/set_password/',
+                headers={'Accept': 'application/json'},
+                json={'password': password},
+            )
+
+            json_content = rv.get_json()
+            key = re.search(r'https://localhost/([^"]+)', json_content['link']).group(1)
+            key = unquote(key)
+
+            frozen_time.move_to("2020-05-22 11:59:59")
+            self.assertEqual(snappass.get_password(key), password)
+
+            frozen_time.move_to("2020-05-22 12:00:00")
+            self.assertIsNone(snappass.get_password(key))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Largely, this is just pulling in the latest from the upstream repo.
There's one template where I'm keeping a local change I made which includes our TrackAbout logo at the top of every page and changes the name of the app to show my preferred string. Otherwise, everything is stock snappass.


- **Remove py3.7 (#234)**
- **Bump cryptography from 39.0.2 to 41.0.1 (#260)**
- **Bump tox from 3.25.0 to 4.6.0 (#262)**
- **Bump fakeredis from 1.7.5 to 2.14.1 (#263)**
- **Bump flask from 2.1.2 to 2.3.2 (#250)**
- **Bump pytest from 7.1.2 to 7.3.1 (#243)**
- **Bump redis from 4.5.3 to 4.5.5 (#253)**
- **Bump coverage from 6.4.1 to 7.2.7 (#267)**
- **Bump pytest-cov from 3.0.0 to 4.1.0 (#266)**
- **Bump actions/checkout from 3 to 4 (#282)**
- **[Snyk] Security upgrade cryptography from 41.0.1 to 41.0.4 (#284)**
- **Bump tox from 4.6.0 to 4.11.3 (#287)**
- **Bump fakeredis from 2.14.1 to 2.20.0**
- **Bump redis from 4.5.5 to 5.0.1**
- **Install deps from requirements.txt (#303)**
- **Prepare 1.6.1 release (#304)**
- **Bump version: 1.6.0 → 1.6.1 (#305)**
- **Use urllib.parse for quoting/unquoting plus instead of deprecated werkzeug.urls (#300)**
- **Bump actions/setup-python from 4 to 5 (#306)**
- **Bump github/codeql-action from 2 to 3 (#309)**
- **Bump werkzeug from 2.3.3 to 3.0.1 (#295)**
- **Bump flask from 2.3.2 to 3.0.0 (#294)**
- **Bump pytest from 7.3.1 to 7.4.4**
- **Bump version: 1.6.1 → 1.6.2 (#311)**
- **Bump freezegun from 1.2.1 to 1.4.0**
- **Bump flake8 from 6.0.0 to 7.0.0**
- **Add health check endpoint (#329)**
- **add i18n to Snappass**
- **Bump fakeredis from 2.20.0 to 2.21.1**
- **remove import of flask**
- **Add empty translations for de and es**
- **Bump cryptography from 41.0.4 to 42.0.3**
- **Add German Translation**
- **Bump pytest from 7.4.4 to 8.0.1**
- **Bump coverage from 7.2.7 to 7.4.2**
- **Bump tox from 4.11.3 to 4.13.0**
- **fix missing bracket**
- **restore extra spaces**
- **Add Spanish and fixup NL&DE**
- **TIL flake8 :)**
- **Bump actions/cache from 3 to 4 (#320)**
- **Bump jinja2 from 3.1.2 to 3.1.3 (#336)**
- **add /api endpoint for automated flows (#316)**
- **Bump pytest from 8.0.1 to 8.1.0**
