### PR TITLE
ls/latest updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,10 @@ WORKDIR $APP_DIR
 COPY ["setup.py", "requirements.txt", "MANIFEST.in", "README.rst", "AUTHORS.rst", "$APP_DIR/"]
 COPY ["./snappass", "$APP_DIR/snappass"]
 
+RUN pip install -r requirements.txt
+
+RUN pybabel compile -d snappass/translations
+
 RUN python setup.py install && \
     chown -R snappass $APP_DIR && \
     chgrp -R snappass $APP_DIR

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 include *.rst LICENSE
 recursive-include snappass/static *
 recursive-include snappass/templates *
+recursive-include snappass/translations *

--- a/README.rst
+++ b/README.rst
@@ -96,12 +96,21 @@ need to change this.
 
 ``HOST_OVERRIDE``: (optional) Used to override the base URL if the app is unaware. Useful when running behind reverse proxies like an identity-aware SSO. Example: ``sub.domain.com``
 
-API
----
+``SNAPPASS_BIND_ADDRESS``: (optional) Used to override the default bind address of 0.0.0.0 for flask app Example: ``127.0.0.1``
 
-SnapPass also has a simple API that can be used to create passwords links. The advantage of using the API is that
-you can create a password and retrieve the link without having to open the web interface. This is useful if you want to
-embed it in a script or use it in a CI/CD pipeline.
+``SNAPPASS_PORT``: (optional) Used to override the default port of 5000 Example: ``6000``
+
+APIs
+----
+
+SnapPass has 2 APIs :
+1. A simple API : That can be used to create passwords links, and then share them with users
+2. A more REST-y API : Which facilitate programmatic interactions with SnapPass, without having to parse HTML content when retrieving the password
+
+Simple API
+^^^^^^^^^^
+
+The advantage of using the simple API is that you can create a password and retrieve the link without having to open the web interface. This is useful if you want to embed it in a script or use it in a CI/CD pipeline.
 
 To create a password, send a POST request to ``/api/set_password`` like so:
 
@@ -124,11 +133,148 @@ the default TTL is 2 weeks (1209600 seconds), but you can override it by adding 
 
     $ curl -X POST -H "Content-Type: application/json"  -d '{"password": "foobar", "ttl": 3600 }' http://localhost:5000/api/set_password/
 
+
+REST API
+^^^^^^^^
+
+The advantage of using the REST API is that you can fully manage the lifecycle of the password stored in SnapPass without having to interact with any web user interface.
+
+This is useful if you want to embed it in a script,  use it in a CI/CD pipeline or share it between multiple client applications.
+
+Create a password
+"""""""""""""""""
+
+To create a password, send a POST request to ``/api/v2/passwords`` like so:
+
+::
+
+    $ curl -X POST -H "Content-Type: application/json"  -d '{"password": "foobar"}' http://localhost:5000/api/v2/passwords
+
+This will return a JSON response with a token and the password link:
+
+::
+
+    {
+        "token": "snappassbedf19b161794fd288faec3eba15fa41~hHnILpQ50ZfJc3nurDfHCb_22rBr5gGEya68e_cZOrY=",
+        "links": [{
+            "rel": "self",
+            "href": "http://127.0.0.1:5000/api/v2/passwords/snappassbedf19b161794fd288faec3eba15fa41~hHnILpQ50ZfJc3nurDfHCb_22rBr5gGEya68e_cZOrY%3D",
+        },{
+            "rel": "web-view",
+            "href": "http://127.0.0.1:5000/snappassbedf19b161794fd288faec3eba15fa41~hHnILpQ50ZfJc3nurDfHCb_22rBr5gGEya68e_cZOrY%3D",
+        }],
+        "ttl":1209600
+    }
+
+The default TTL is 2 weeks (1209600 seconds), but you can override it by adding a expiration parameter:
+
+::
+
+    $ curl -X POST -H "Content-Type: application/json"  -d '{"password": "foobar", "ttl": 3600 }' http://localhost:5000/api/v2/passwords
+
+If the password is null or empty, and the TTL is larger than the max TTL of the application, the API will return an error like this:
+
+
+Otherwise, the API will return a 404 (Not Found) response like so:
+
+::
+
+    {
+        "invalid-params": [{
+            "name": "password",
+            "reason": "The password is required and should not be null or empty."
+        }, {
+            "name": "ttl",
+            "reason": "The specified TTL is longer than the maximum supported."
+        }],
+        "title": "The password and/or the TTL are invalid.",
+        "type": "https://127.0.0.1:5000/set-password-validation-error"
+    }
+
+Check if a password exists
+""""""""""""""""""""""""""
+
+To check if a password exists, send a HEAD request to ``/api/v2/passwords/<token>``, where ``<token>`` is the token of the API response when a password is created (url encoded), or simply use the `self` link:
+
+::
+
+    $ curl --head http://localhost:5000/api/v2/passwords/snappassbedf19b161794fd288faec3eba15fa41~hHnILpQ50ZfJc3nurDfHCb_22rBr5gGEya68e_cZOrY%3D
+
+If :
+- the passwork_key is valid
+- the password :
+  - exists,
+  - has not been read
+  - is not expired
+
+Then the API will return a 200 (OK) response like so:
+
+::
+
+    HTTP/1.1 200 OK
+    Server: Werkzeug/3.0.1 Python/3.12.2
+    Date: Fri, 29 Mar 2024 22:15:54 GMT
+    Content-Type: text/html; charset=utf-8
+    Content-Length: 0
+    Connection: close
+
+Otherwise, the API will return a 404 (Not Found) response like so:
+
+::
+
+    HTTP/1.1 404 NOT FOUND
+    Server: Werkzeug/3.0.1 Python/3.12.2
+    Date: Fri, 29 Mar 2024 22:19:29 GMT
+    Content-Type: text/html; charset=utf-8
+    Content-Length: 0
+    Connection: close
+
+
+Read a password
+"""""""""""""""
+
+To read a password, send a GET request to ``/api/v2/passwords/<password_key>``, where ``<password_key>`` is the token of the API response when a password is created, or simply use the `self` link:
+
+::
+
+    $ curl -X GET http://localhost:5000/api/v2/passwords/snappassbedf19b161794fd288faec3eba15fa41~hHnILpQ50ZfJc3nurDfHCb_22rBr5gGEya68e_cZOrY%3D
+
+If :
+- the token is valid
+- the password :
+  - exists
+  - has not been read
+  - is not expired
+
+Then the API will return a 200 (OK) with a JSON response containing the password :
+
+::
+
+    {
+        "password": "foobar"
+    }
+
+Otherwise, the API will return a 404 (Not Found) response like so:
+
+::
+
+    {
+        "invalid-params": [{
+            "name": "token"
+        }],
+        "title": "The password doesn't exist.",
+        "type": "https://127.0.0.1:5000/get-password-error"
+    }
+
+Notes on APIs
+^^^^^^^^^^^^^
+
 Notes:
 
-- When using the API, you can specify any ttl, as long as it is lower than the default.
+- When using the APIs, you can specify any ttl, as long as it is lower than the default.
 - The password is passed in the body of the request rather than in the URL. This is to prevent the password from being logged in the server logs.
 - Depending on the environment you are running it, you might want to expose the ``/api`` endpoint to your internal network only, and put the web interface behind authentication.
+
 
 Docker
 ------

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,9 +1,9 @@
-coverage==7.4.2
-fakeredis==2.21.1
-flake8==7.0.0
-freezegun==1.4.0
-pytest==8.1.0
-pytest-cov==4.1.0
-tox==4.13.0
+coverage==7.6.0
+fakeredis==2.25.1
+flake8==7.1.1
+freezegun==1.5.1
+pytest==8.3.2
+pytest-cov==5.0.0
+tox==4.23.0
 bumpversion==0.6.0
-wheel==0.42.0
+wheel==0.44.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
     snappass:
-        image: snappass:v1.6.2
+        image: trackabout/snappass:main
         ports:
             - "5000:5000"
         stop_signal: SIGINT

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
-cryptography==42.0.4
+cryptography==43.0.1
 Flask==3.0.0
-itsdangerous==2.1.2
+itsdangerous==2.2.0
 Jinja2==3.1.4
 MarkupSafe==2.1.1
-redis==5.0.1
+redis==5.1.1
 Werkzeug==3.0.3
 flask-babel

--- a/tests.py
+++ b/tests.py
@@ -4,6 +4,7 @@ import unittest
 import uuid
 from unittest import TestCase
 from unittest import mock
+from urllib.parse import quote
 from urllib.parse import unquote
 
 from cryptography.fernet import Fernet
@@ -200,6 +201,156 @@ class SnapPassRoutesTestCase(TestCase):
 
             frozen_time.move_to("2020-05-22 12:00:00")
             self.assertIsNone(snappass.get_password(key))
+
+    def test_set_password_api_v2(self):
+        with freeze_time("2020-05-08 12:00:00") as frozen_time:
+            password = 'my name is my passport. verify me.'
+            rv = self.app.post(
+                '/api/v2/passwords',
+                headers={'Accept': 'application/json'},
+                json={'password': password, 'ttl': '1209600'},
+            )
+
+            json_content = rv.get_json()
+            key = unquote(json_content['token'])
+
+            frozen_time.move_to("2020-05-22 11:59:59")
+            self.assertEqual(snappass.get_password(key), password)
+
+            frozen_time.move_to("2020-05-22 12:00:00")
+            self.assertIsNone(snappass.get_password(key))
+
+    def test_set_password_api_v2_default_ttl(self):
+        with freeze_time("2020-05-08 12:00:00") as frozen_time:
+            password = 'my name is my passport. verify me.'
+            rv = self.app.post(
+                '/api/v2/passwords',
+                headers={'Accept': 'application/json'},
+                json={'password': password},
+            )
+
+            json_content = rv.get_json()
+            key = unquote(json_content['token'])
+
+            frozen_time.move_to("2020-05-22 11:59:59")
+            self.assertEqual(snappass.get_password(key), password)
+
+            frozen_time.move_to("2020-05-22 12:00:00")
+            self.assertIsNone(snappass.get_password(key))
+
+    def test_set_password_api_v2_no_password(self):
+        rv = self.app.post(
+            '/api/v2/passwords',
+            headers={'Accept': 'application/json'},
+            json={'password': ''},
+        )
+
+        self.assertEqual(rv.status_code, 400)
+
+        json_content = rv.get_json()
+        invalid_params = json_content['invalid-params']
+        self.assertEqual(len(invalid_params), 1)
+        bad_password = invalid_params[0]
+        self.assertEqual(bad_password['name'], 'password')
+
+    def test_set_password_api_v2_too_big_ttl(self):
+        password = 'my name is my passport. verify me.'
+        rv = self.app.post(
+            '/api/v2/passwords',
+            headers={'Accept': 'application/json'},
+            json={'password': password, 'ttl': '1209600000'},
+        )
+
+        self.assertEqual(rv.status_code, 400)
+
+        json_content = rv.get_json()
+        invalid_params = json_content['invalid-params']
+        self.assertEqual(len(invalid_params), 1)
+        bad_ttl = invalid_params[0]
+        self.assertEqual(bad_ttl['name'], 'ttl')
+
+    def test_set_password_api_v2_no_password_and_too_big_ttl(self):
+        rv = self.app.post(
+            '/api/v2/passwords',
+            headers={'Accept': 'application/json'},
+            json={'password': '', 'ttl': '1209600000'},
+        )
+
+        self.assertEqual(rv.status_code, 400)
+
+        json_content = rv.get_json()
+        invalid_params = json_content['invalid-params']
+        self.assertEqual(len(invalid_params), 2)
+        bad_password = invalid_params[0]
+        self.assertEqual(bad_password['name'], 'password')
+        bad_ttl = invalid_params[1]
+        self.assertEqual(bad_ttl['name'], 'ttl')
+
+    def test_check_password_api_v2(self):
+        password = 'my name is my passport. verify me.'
+        rv = self.app.post(
+            '/api/v2/passwords',
+            headers={'Accept': 'application/json'},
+            json={'password': password},
+        )
+
+        json_content = rv.get_json()
+        key = unquote(json_content['token'])
+
+        rvc = self.app.head('/api/v2/passwords/' + quote(key))
+        self.assertEqual(rvc.status_code, 200)
+
+    def test_check_password_api_v2_bad_keys(self):
+        password = 'my name is my passport. verify me.'
+        rv = self.app.post(
+            '/api/v2/passwords',
+            headers={'Accept': 'application/json'},
+            json={'password': password},
+        )
+
+        json_content = rv.get_json()
+        key = unquote(json_content['token'])
+
+        rvc = self.app.head('/api/v2/passwords/' + quote(key[::-1]))
+        self.assertEqual(rvc.status_code, 404)
+
+    def test_retrieve_password_api_v2(self):
+        password = 'my name is my passport. verify me.'
+        rv = self.app.post(
+            '/api/v2/passwords',
+            headers={'Accept': 'application/json'},
+            json={'password': password},
+        )
+
+        json_content = rv.get_json()
+        key = unquote(json_content['token'])
+
+        rvc = self.app.get('/api/v2/passwords/' + quote(key))
+        self.assertEqual(rv.status_code, 200)
+
+        json_content_retrieved = rvc.get_json()
+        retrieved_password = json_content_retrieved['password']
+        self.assertEqual(retrieved_password, password)
+
+    def test_retrieve_password_api_v2_bad_keys(self):
+        password = 'my name is my passport. verify me.'
+        rv = self.app.post(
+            '/api/v2/passwords',
+            headers={'Accept': 'application/json'},
+            json={'password': password},
+        )
+
+        json_content = rv.get_json()
+        key = unquote(json_content['token'])
+
+        rvc = self.app.get('/api/v2/passwords/' + quote(key[::-1]))
+        self.assertEqual(rvc.status_code, 404)
+
+        json_content_retrieved = rvc.get_json()
+        invalid_params = json_content_retrieved['invalid-params']
+        self.assertEqual(len(invalid_params), 1)
+        bad_token = invalid_params[0]
+        self.assertEqual(bad_token['name'], 'token')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
- **Remove py3.7 (#234)**
- **Bump cryptography from 39.0.2 to 41.0.1 (#260)**
- **Bump tox from 3.25.0 to 4.6.0 (#262)**
- **Bump fakeredis from 1.7.5 to 2.14.1 (#263)**
- **Bump flask from 2.1.2 to 2.3.2 (#250)**
- **Bump pytest from 7.1.2 to 7.3.1 (#243)**
- **Bump redis from 4.5.3 to 4.5.5 (#253)**
- **Bump coverage from 6.4.1 to 7.2.7 (#267)**
- **Bump pytest-cov from 3.0.0 to 4.1.0 (#266)**
- **Bump actions/checkout from 3 to 4 (#282)**
- **[Snyk] Security upgrade cryptography from 41.0.1 to 41.0.4 (#284)**
- **Bump tox from 4.6.0 to 4.11.3 (#287)**
- **Bump fakeredis from 2.14.1 to 2.20.0**
- **Bump redis from 4.5.5 to 5.0.1**
- **Install deps from requirements.txt (#303)**
- **Prepare 1.6.1 release (#304)**
- **Bump version: 1.6.0 → 1.6.1 (#305)**
- **Use urllib.parse for quoting/unquoting plus instead of deprecated werkzeug.urls (#300)**
- **Bump actions/setup-python from 4 to 5 (#306)**
- **Bump github/codeql-action from 2 to 3 (#309)**
- **Bump werkzeug from 2.3.3 to 3.0.1 (#295)**
- **Bump flask from 2.3.2 to 3.0.0 (#294)**
- **Bump pytest from 7.3.1 to 7.4.4**
- **Bump version: 1.6.1 → 1.6.2 (#311)**
- **Bump freezegun from 1.2.1 to 1.4.0**
- **Bump flake8 from 6.0.0 to 7.0.0**
- **Add health check endpoint (#329)**
- **add i18n to Snappass**
- **Bump fakeredis from 2.20.0 to 2.21.1**
- **remove import of flask, g**
- **Add empty translations for de and es**
- **Bump cryptography from 41.0.4 to 42.0.3**
- **Add German Translation**
- **Bump pytest from 7.4.4 to 8.0.1**
- **Bump coverage from 7.2.7 to 7.4.2**
- **Bump tox from 4.11.3 to 4.13.0**
- **fix missing bracket**
- **restore extra spaces**
- **Add Spanish and fixup NL&DE**
- **TIL flake8 :)**
- **Bump actions/cache from 3 to 4 (#320)**
- **Bump jinja2 from 3.1.2 to 3.1.3 (#336)**
- **add /api endpoint for automated flows (#316)**
- **Bump pytest from 8.0.1 to 8.1.0**
- **Bump pytest-cov from 4.1.0 to 5.0.0**
- **:construction: Add a 'modern' REST API**
- **:construction: Add RFC7807 response type**
- **:construction: Import missing parts**
- **:art: Cleanup**
- **:recycle: Use token as name for password_key**
- **:technologist: Use HATEHOAS style**
- **:white_check_mark: Finish test suite implementation**
- **:memo: Add documentation about new APIs**
- **:art: flake8**
- **:children_crossing: Remove URL encoding from token**
- **:children_crossing: Add a link to web view**
- **Bump wheel from 0.42.0 to 0.43.0**
- **fix: requirements.txt to reduce vulnerabilities**
- **Bump tox from 4.13.0 to 4.16.0 (#376)**
- **Bump coverage from 7.4.2 to 7.6.0 (#379)**
- **Bump fakeredis from 2.21.1 to 2.23.4 (#381)**
- **[Snyk] Security upgrade cryptography from 42.0.3 to 42.0.8 (#371)**
- **Bump freezegun from 1.4.0 to 1.5.1 (#362)**
- **[Snyk] Security upgrade jinja2 from 3.1.3 to 3.1.4 (#359)**
- **Bump itsdangerous from 2.1.2 to 2.2.0 (#347)**
- **Environment variables for default port and bind address (#342)**
- **Bump cryptography from 42.0.8 to 43.0.0 (#382)**
- **Bump pytest from 8.1.0 to 8.3.2 (#385)**
- **Bump flake8 from 7.0.0 to 7.1.1 (#383)**
- **Bump wheel from 0.43.0 to 0.44.0 (#384)**
- **Bump tox from 4.16.0 to 4.17.0 (#386)**
- **Bump tox from 4.17.0 to 4.18.0 (#388)**
- **Bump fakeredis from 2.23.4 to 2.24.1 (#390)**
- **fix i18n (#375)**
- **[Snyk] Security upgrade cryptography from 43.0.0 to 43.0.1 (#391)**
- **Bump tox from 4.18.0 to 4.23.0 (#405)**
- **Bump fakeredis from 2.24.1 to 2.25.1 (#397)**
- **Bump redis from 5.0.1 to 5.1.1 (#401)**
